### PR TITLE
Remove `ref_name` from artifact name

### DIFF
--- a/.github/workflows/tex.yml
+++ b/.github/workflows/tex.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: 线性代数荣誉课辅学讲义-${{ github.ref_name }}-${{ github.run_number }}.pdf
+          name: 线性代数荣誉课辅学讲义-${{ github.run_number }}.pdf
           path: |
             ${{ github.workspace }}/讲义/线性代数荣誉课辅学讲义.pdf


### PR DESCRIPTION
Because pull request builds are failing because of `github.ref_name` containing slashes.